### PR TITLE
adiciona "git config --global push.default matching"

### DIFF
--- a/mac-install.sh
+++ b/mac-install.sh
@@ -31,6 +31,10 @@ brew tap josegonzalez/homebrew-php
 brew install php55 --with-apache
 brew link php55
 
+# Configuração do push do git. O parametro 'matching' efetua push para todos os branchs com mesmo nome em repos diferentes
+# @see http://git-scm.com/docs/git-config (Procurar por push.default)
+git config --global push.default matching
+
 # http://caskroom.io/
 brew install phinze/cask/brew-cask
 


### PR DESCRIPTION
**push.default**


Defines the action git push should take if no refspec is given on the command line, no refspec is configured in the remote, and no refspec is implied by any of the options given on the command line. Possible values are:

> * **nothing:** do not push anything
> 
> * **matching:** push all matching branches.  All branches having the same name in both ends are considered to be matching. This is the default in Git 1.x.
> 
> * **upstream:** push the current branch to its upstream branch (tracking is a deprecated synonym for upstream)
> 
> * **current:** push the current branch to a branch of the same name 
> * **simple:** (new in Git 1.7.11) like upstream, but refuses to push if the upstream branch's name is different from the local one

This is the safest option and is well-suited for beginners.
This will become the default in Git 2.0.

The simple, current and upstream modes are for those who want to push out a single branch after finishing work, even when the other branches are not yet ready to be pushed out


Command line example:

**git config --global push.default current**